### PR TITLE
Updated links and added PXF references

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -19,7 +19,9 @@ The S3 storage plugin lets you use Minio for Pivotal Greenplum to store and retr
 
 Using S3 Storage Plugin with gpbackup and gprestore: [link](https://gpdb.docs.pivotal.io/5150/admin_guide/managing/backup-s3-plugin.html)
 
-Greenplum S3 configuration: [link](https://gpdb.docs.pivotal.io/5150/admin_guide/external/g-s3-protocol.html)
+Using Greenplum PXF protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/pxf/access_objstore.html)
+
+Using Greenplum S3 protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/admin_guide/external/g-s3-protocol.html)
 
 
 
@@ -33,7 +35,9 @@ Greenplum database supports loading and unloading data from several types of ext
 
 Loading and Unloading Data: [link](https://gpdb.docs.pivotal.io/530/admin_guide/load/topics/g-loading-and-unloading-data.html)
 
-Greenplum S3 configuration: [link](https://gpdb.docs.pivotal.io/5150/admin_guide/external/g-s3-protocol.html)
+Using Greenplum PXF protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/pxf/access_objstore.html)
+
+Using Greenplum S3 protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/admin_guide/external/g-s3-protocol.html)
 
 
 
@@ -43,5 +47,6 @@ Greenplum developers can query data held in an S3 external table. Data stored in
 
 Defining External Tables: [link](https://gpdb.docs.pivotal.io/530/admin_guide/external/g-external-tables.html)
 
-Greenplum S3 configuration: [link](https://gpdb.docs.pivotal.io/5150/admin_guide/external/g-s3-protocol.html)
+Using Greenplum PXF protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/pxf/access_objstore.html)
 
+Using Greenplum S3 protocol to access S3: [link](https://gpdb.docs.pivotal.io/latest/admin_guide/external/g-s3-protocol.html)


### PR DESCRIPTION
1) Changed from specific version to "latest" so that users will always view the latest documentation

2) Added reference to PXF since PXF is the preferred protocol to access S3 object storage.